### PR TITLE
Fix division by zero in StopWhenReturnsDiminish criterion

### DIFF
--- a/mapmap/source/termination_instances/stop_when_returns_diminish.impl.h
+++ b/mapmap/source/termination_instances/stop_when_returns_diminish.impl.h
@@ -54,6 +54,10 @@ check_termination(
     /* determine improvement in the last couple of iterations */
     newest_val = history->energy_history->back();
 
+    /* terminate if objective is already 0 */
+    if (newest_val == static_cast<_s_t<COSTTYPE, SIMDWIDTH>>(0))
+        return true;
+
     luint_t oldest_pos = 0;
     if(hist_size > m_iteration_span)
         oldest_pos = (hist_size - 1) - m_iteration_span;


### PR DESCRIPTION
Hi @dthuerck,
this happens for example if the graph doesn't have any edges.
Is this the right way to terminate? Can the cost go below 0?
Best,
Stepan
