### PR TITLE
Fix windows build

### DIFF
--- a/mapmap/full.h
+++ b/mapmap/full.h
@@ -15,48 +15,48 @@
 #define __MAPMAP_FULL_H_
 
 /* basic classes */
-#include "header/color.h"
-#include "header/costs.h"
-#include "header/defines.h"
-#include "header/graph.h"
-#include "header/mapmap.h"
-#include "header/multilevel.h"
-#include "header/parallel_templates.h"
-#include "header/termination_criterion.h"
-#include "header/timer.h"
-#include "header/tree_optimizer.h"
-#include "header/tree_sampler.h"
-#include "header/tree.h"
-#include "header/vector_math.h"
-#include "header/vector_types.h"
+#include <mapmap/header/color.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/defines.h>
+#include <mapmap/header/graph.h>
+#include <mapmap/header/mapmap.h>
+#include <mapmap/header/multilevel.h>
+#include <mapmap/header/parallel_templates.h>
+#include <mapmap/header/termination_criterion.h>
+#include <mapmap/header/timer.h>
+#include <mapmap/header/tree_optimizer.h>
+#include <mapmap/header/tree_sampler.h>
+#include <mapmap/header/tree.h>
+#include <mapmap/header/vector_math.h>
+#include <mapmap/header/vector_types.h>
 
 /* cost functions */
-#include "header/cost_instances/pairwise_antipotts.h"
-#include "header/cost_instances/pairwise_linear_peak.h"
-#include "header/cost_instances/pairwise_potts.h"
-#include "header/cost_instances/pairwise_table.h"
-#include "header/cost_instances/pairwise_truncated_linear.h"
-#include "header/cost_instances/pairwise_truncated_quadratic.h"
-#include "header/cost_instances/unary_table.h"
+#include <mapmap/header/cost_instances/pairwise_antipotts.h>
+#include <mapmap/header/cost_instances/pairwise_linear_peak.h>
+#include <mapmap/header/cost_instances/pairwise_potts.h>
+#include <mapmap/header/cost_instances/pairwise_table.h>
+#include <mapmap/header/cost_instances/pairwise_truncated_linear.h>
+#include <mapmap/header/cost_instances/pairwise_truncated_quadratic.h>
+#include <mapmap/header/cost_instances/unary_table.h>
 
 /* multilevel instances */
-#include "header/multilevel_instances/group_same_label.h"
+#include <mapmap/header/multilevel_instances/group_same_label.h>
 
 /* optimizer instances */
-#include "header/optimizer_instances/dp_node_solver_factory.h"
-#include "header/optimizer_instances/dp_node_solver.h"
-#include "header/optimizer_instances/dp_node.h"
-#include "header/optimizer_instances/dynamic_programming.h"
-#include "header/optimizer_instances/envelope.h"
+#include <mapmap/header/optimizer_instances/dp_node_solver_factory.h>
+#include <mapmap/header/optimizer_instances/dp_node_solver.h>
+#include <mapmap/header/optimizer_instances/dp_node.h>
+#include <mapmap/header/optimizer_instances/dynamic_programming.h>
+#include <mapmap/header/optimizer_instances/envelope.h>
 
 /* termination criteria */
-#include "header/termination_instances/stop_after_iterations.h"
-#include "header/termination_instances/stop_after_time.h"
-#include "header/termination_instances/stop_when_flat.h"
-#include "header/termination_instances/stop_when_returns_diminish.h"
+#include <mapmap/header/termination_instances/stop_after_iterations.h>
+#include <mapmap/header/termination_instances/stop_after_time.h>
+#include <mapmap/header/termination_instances/stop_when_flat.h>
+#include <mapmap/header/termination_instances/stop_when_returns_diminish.h>
 
 /* tree sampler instances */
-#include "header/tree_sampler_instances/lock_free_tree_sampler.h"
-#include "header/tree_sampler_instances/optimistic_tree_sampler.h"
+#include <mapmap/header/tree_sampler_instances/lock_free_tree_sampler.h>
+#include <mapmap/header/tree_sampler_instances/optimistic_tree_sampler.h>
 
 #endif /* __MAPMAP_FULL_H_ */

--- a/mapmap/header/color.h
+++ b/mapmap/header/color.h
@@ -10,10 +10,10 @@
 #ifndef __MAPMAP_COLOR_H_
 #define __MAPMAP_COLOR_H_
 
-#include "tbb/concurrent_vector.h"
-#include "header/defines.h"
+#include <tbb/concurrent_vector.h>
+#include <mapmap/header/defines.h>
 
-#include "header/graph.h"
+#include <mapmap/header/graph.h>
 
 NS_MAPMAP_BEGIN
 
@@ -47,6 +47,6 @@ protected:
 
 NS_MAPMAP_END
 
-#include "source/color.impl.h"
+#include <mapmap/source/color.impl.h>
 
 #endif /* __MAPMAP_COLOR_H_ */

--- a/mapmap/header/cost_bundle.h
+++ b/mapmap/header/cost_bundle.h
@@ -10,9 +10,9 @@
 #ifndef __MAPMAP_HEADER_COST_BUNDLE_H_
 #define __MAPMAP_HEADER_COST_BUNDLE_H_
 
-#include "header/defines.h"
-#include "header/costs.h"
-#include "header/graph.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/graph.h>
 
 NS_MAPMAP_BEGIN
 
@@ -49,6 +49,6 @@ protected:
 NS_MAPMAP_END
 
 /* include template instances */
-#include "source/cost_bundle.impl.h"
+#include <mapmap/source/cost_bundle.impl.h>
 
 #endif /* __MAPMAP_HEADER_COST_BUNDLE_H_ */

--- a/mapmap/header/cost_instances/pairwise_antipotts.h
+++ b/mapmap/header/cost_instances/pairwise_antipotts.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_PAIRWISE_ANTIPOTTS_H_
 #define __MAPMAP_PAIRWISE_ANTIPOTTS_H_
 
-#include "header/costs.h"
+#include <mapmap/header/costs.h>
 
 NS_MAPMAP_BEGIN
 
@@ -46,6 +46,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/cost_instances/pairwise_antipotts.impl.h"
+#include <mapmap/source/cost_instances/pairwise_antipotts.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_ANTIPOTTS_H_ */

--- a/mapmap/header/cost_instances/pairwise_linear_peak.h
+++ b/mapmap/header/cost_instances/pairwise_linear_peak.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_PAIRWISE_LINEAR_PEAK_H_
 #define __MAPMAP_PAIRWISE_LINEAR_PEAK_H_
 
-#include "header/costs.h"
+#include <mapmap/header/costs.h>
 
 NS_MAPMAP_BEGIN
 
@@ -52,6 +52,6 @@ using PairwiseLinearPeak_ptr =
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/cost_instances/pairwise_linear_peak.impl.h"
+#include <mapmap/source/cost_instances/pairwise_linear_peak.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_LINEAR_PEAK_H_ */

--- a/mapmap/header/cost_instances/pairwise_potts.h
+++ b/mapmap/header/cost_instances/pairwise_potts.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_PAIRWISE_POTTS_H_
 #define __MAPMAP_PAIRWISE_POTTS_H_
 
-#include "header/costs.h"
+#include <mapmap/header/costs.h>
 
 NS_MAPMAP_BEGIN
 
@@ -47,6 +47,6 @@ using PairwisePotts_ptr = std::shared_ptr<PairwisePotts<COSTTYPE, SIMDWIDTH>>;
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/cost_instances/pairwise_potts.impl.h"
+#include <mapmap/source/cost_instances/pairwise_potts.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_POTTS_H_ */

--- a/mapmap/header/cost_instances/pairwise_table.h
+++ b/mapmap/header/cost_instances/pairwise_table.h
@@ -13,11 +13,11 @@
 #include <memory>
 #include <vector>
 
-#include "header/defines.h"
-#include "header/costs.h"
-#include "header/graph.h"
-#include "header/vector_types.h"
-#include "header/vector_math.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/graph.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/vector_math.h>
 
 NS_MAPMAP_BEGIN
 
@@ -71,6 +71,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/cost_instances/pairwise_table.impl.h"
+#include <mapmap/source/cost_instances/pairwise_table.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_TABLE_H_ */

--- a/mapmap/header/cost_instances/pairwise_truncated_linear.h
+++ b/mapmap/header/cost_instances/pairwise_truncated_linear.h
@@ -10,8 +10,8 @@
 #ifndef __MAPMAP_PAIRWISE_TRUNCATED_LINEAR_H_
 #define __MAPMAP_PAIRWISE_TRUNCATED_LINEAR_H_
 
-#include "header/defines.h"
-#include "header/costs.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/costs.h>
 
 NS_MAPMAP_BEGIN
 
@@ -53,6 +53,6 @@ using PairwiseTruncatedLinear_ptr = std::shared_ptr<PairwiseTruncatedLinear<
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/cost_instances/pairwise_truncated_linear.impl.h"
+#include <mapmap/source/cost_instances/pairwise_truncated_linear.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_TRUNCATED_LINEAR_H_ */

--- a/mapmap/header/cost_instances/pairwise_truncated_quadratic.h
+++ b/mapmap/header/cost_instances/pairwise_truncated_quadratic.h
@@ -10,8 +10,8 @@
 #ifndef __MAPMAP_PAIRWISE_TRUNCATED_QUADRATIC_H_
 #define __MAPMAP_PAIRWISE_TRUNCATED_QUADRATIC_H_
 
-#include "header/defines.h"
-#include "header/costs.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/costs.h>
 
 NS_MAPMAP_BEGIN
 
@@ -53,6 +53,6 @@ using PairwiseTruncatedQuadratic_ptr = std::shared_ptr<
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/cost_instances/pairwise_truncated_quadratic.impl.h"
+#include <mapmap/source/cost_instances/pairwise_truncated_quadratic.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_TRUNCATED_QUADRATIC_H_ */

--- a/mapmap/header/cost_instances/unary_table.h
+++ b/mapmap/header/cost_instances/unary_table.h
@@ -12,7 +12,7 @@
 
 #include <vector>
 
-#include "header/costs.h"
+#include <mapmap/header/costs.h>
 
 NS_MAPMAP_BEGIN
 
@@ -47,6 +47,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/cost_instances/unary_table.impl.h"
+#include <mapmap/source/cost_instances/unary_table.impl.h>
 
 #endif /* __MAPMAP_UNARY_TABLE_H_ */

--- a/mapmap/header/costs.h
+++ b/mapmap/header/costs.h
@@ -18,9 +18,9 @@
 #include <algorithm>
 #include <typeinfo>
 
-#include "header/defines.h"
-#include "header/vector_types.h"
-#include "header/vector_math.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/vector_math.h>
 
 NS_MAPMAP_BEGIN
 
@@ -140,6 +140,6 @@ protected:
 
 NS_MAPMAP_END
 
-#include "source/costs.impl.h"
+#include <mapmap/source/costs.impl.h>
 
 #endif /* __MAPMAP_COSTS_H_ */

--- a/mapmap/header/dynamic_programming.h
+++ b/mapmap/header/dynamic_programming.h
@@ -13,17 +13,17 @@
 #include <memory>
 #include <vector>
 
-#include "tbb/blocked_range.h"
-#include "tbb/concurrent_vector.h"
-#include "tbb/tbb_allocator.h"
+#include <tbb/blocked_range.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/tbb_allocator.h>
 
-#include "header/defines.h"
-#include "header/tree.h"
-#include "header/vector_types.h"
-#include "header/vector_math.h"
-#include "header/costs.h"
-#include "header/tree_optimizer.h"
-#include "header/parallel_templates.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/tree.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/vector_math.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/tree_optimizer.h>
+#include <mapmap/header/parallel_templates.h>
 
 NS_MAPMAP_BEGIN
 
@@ -119,6 +119,6 @@ protected:
 
 NS_MAPMAP_END
 
-#include "source/dynamic_programming.impl.h"
+#include <mapmap/source/dynamic_programming.impl.h>
 
 #endif /* __MAPMAP_DYNAMIC_PROGRAMMING_H_ */

--- a/mapmap/header/graph.h
+++ b/mapmap/header/graph.h
@@ -14,8 +14,8 @@
 #include <memory>
 #include <exception>
 
-#include "header/defines.h"
-#include "header/vector_types.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
 
 NS_MAPMAP_BEGIN
 
@@ -78,6 +78,6 @@ protected:
 
 NS_MAPMAP_END
 
-#include "source/graph.impl.h"
+#include <mapmap/source/graph.impl.h>
 
 #endif /* __MAPMAP_GRAPH_H_ */

--- a/mapmap/header/instance_factory.h
+++ b/mapmap/header/instance_factory.h
@@ -10,10 +10,10 @@
 #ifndef __MAPMAP_INSTANCE_FACTORY_H_
 #define __MAPMAP_INSTANCE_FACTORY_H_
 
-#include "header/defines.h"
-#include "header/graph.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/graph.h>
 
-#include "header/tree_sampler.h"
+#include <mapmap/header/tree_sampler.h>
 
 #include <memory>
 
@@ -43,6 +43,6 @@ public:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/instance_factory.impl.h"
+#include <mapmap/source/instance_factory.impl.h>
 
 #endif /* __MAPMAP_INSTANCE_FACTORY_H_ */

--- a/mapmap/header/mapmap.h
+++ b/mapmap/header/mapmap.h
@@ -16,19 +16,19 @@
 #include <stdexcept>
 #include <chrono>
 
-#include "header/defines.h"
-#include "header/cost_bundle.h"
-#include "header/instance_factory.h"
-#include "header/vector_types.h"
-#include "header/optimizer_instances/dynamic_programming.h"
-#include "header/graph.h"
-#include "header/multilevel.h"
-#include "header/termination_criterion.h"
-#include "header/tree.h"
-#include "header/tree_optimizer.h"
-#include "header/instance_factory.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/cost_bundle.h>
+#include <mapmap/header/instance_factory.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/optimizer_instances/dynamic_programming.h>
+#include <mapmap/header/graph.h>
+#include <mapmap/header/multilevel.h>
+#include <mapmap/header/termination_criterion.h>
+#include <mapmap/header/tree.h>
+#include <mapmap/header/tree_optimizer.h>
+#include <mapmap/header/instance_factory.h>
 
-#include "tbb/tick_count.h"
+#include <tbb/tick_count.h>
 
 NS_MAPMAP_BEGIN
 
@@ -218,6 +218,6 @@ struct mapMAP_control
 
 NS_MAPMAP_END
 
-#include "source/mapmap.impl.h"
+#include <mapmap/source/mapmap.impl.h>
 
 #endif /* __MAPMAP_MAPMAP_H_ */

--- a/mapmap/header/multilevel.h
+++ b/mapmap/header/multilevel.h
@@ -13,15 +13,15 @@
 #include <memory>
 #include <vector>
 
-#include "tbb/mutex.h"
+#include <tbb/mutex.h>
 
-#include "header/defines.h"
-#include "header/graph.h"
-#include "header/costs.h"
-#include "header/cost_bundle.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/graph.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/cost_bundle.h>
 
-#include "header/cost_instances/unary_table.h"
-#include "header/cost_instances/pairwise_table.h"
+#include <mapmap/header/cost_instances/unary_table.h>
+#include <mapmap/header/cost_instances/pairwise_table.h>
 
 NS_MAPMAP_BEGIN
 
@@ -173,6 +173,6 @@ protected:
 
 NS_MAPMAP_END
 
-#include "source/multilevel.impl.h"
+#include <mapmap/source/multilevel.impl.h>
 
 #endif /* __MAPMAP_MULTILEVEL_H_ */

--- a/mapmap/header/multilevel_instances/group_same_label.h
+++ b/mapmap/header/multilevel_instances/group_same_label.h
@@ -13,9 +13,9 @@
 #include <memory>
 #include <vector>
 
-#include "header/multilevel.h"
+#include <mapmap/header/multilevel.h>
 
-#include "tbb/mutex.h"
+#include <tbb/mutex.h>
 
 NS_MAPMAP_BEGIN
 
@@ -36,6 +36,6 @@ public:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/multilevel_instances/group_same_label.impl.h"
+#include <mapmap/source/multilevel_instances/group_same_label.impl.h>
 
 #endif /* __MAPMAP_GROUP_SAME_LABEL_H_ */

--- a/mapmap/header/optimizer_instances/dp_node.h
+++ b/mapmap/header/optimizer_instances/dp_node.h
@@ -10,11 +10,11 @@
 #ifndef __MAPMAP_HEADER_OPTIMIZER_INSTANCES_DP_NODE_H_
 #define __MAPMAP_HEADER_OPTIMIZER_INSTANCES_DP_NODE_H_
 
-#include "header/defines.h"
-#include "header/vector_types.h"
-#include "header/vector_math.h"
-#include "header/parallel_templates.h"
-#include "header/costs.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/vector_math.h>
+#include <mapmap/header/parallel_templates.h>
+#include <mapmap/header/costs.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/header/optimizer_instances/dp_node_solver.h
+++ b/mapmap/header/optimizer_instances/dp_node_solver.h
@@ -10,9 +10,9 @@
 #ifndef __MAPMAP_HEADER_DP_NODE_SOLVER_H_
 #define __MAPMAP_HEADER_DP_NODE_SOLVER_H_
 
-#include "header/defines.h"
-#include "header/vector_types.h"
-#include "header/optimizer_instances/dp_node.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/optimizer_instances/dp_node.h>
 
 NS_MAPMAP_BEGIN
 
@@ -109,6 +109,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/dp_node_solver.impl.h"
+#include <mapmap/source/optimizer_instances/dp_node_solver.impl.h>
 
 #endif /* __MAPMAP_HEADER_DP_NODE_SOLVER_H_ */

--- a/mapmap/header/optimizer_instances/dp_node_solver_factory.h
+++ b/mapmap/header/optimizer_instances/dp_node_solver_factory.h
@@ -10,11 +10,11 @@
 #ifndef __MAPMAP_DP_NODE_SOLVER_FACTORY_H_
 #define __MAPMAP_DP_NODE_SOLVER_FACTORY_H_
 
-#include "header/defines.h"
-#include "header/costs.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/costs.h>
 
-#include "header/optimizer_instances/envelope.h"
-#include "header/optimizer_instances/dp_node_solver.h"
+#include <mapmap/header/optimizer_instances/envelope.h>
+#include <mapmap/header/optimizer_instances/dp_node_solver.h>
 
 NS_MAPMAP_BEGIN
 
@@ -31,6 +31,6 @@ public:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/dp_node_solver_factory.impl.h"
+#include <mapmap/source/optimizer_instances/dp_node_solver_factory.impl.h>
 
 #endif /* __MAPMAP_DP_NODE_SOLVER_FACTORY_H_ */

--- a/mapmap/header/optimizer_instances/dynamic_programming.h
+++ b/mapmap/header/optimizer_instances/dynamic_programming.h
@@ -13,19 +13,19 @@
 #include <memory>
 #include <vector>
 
-#include "tbb/blocked_range.h"
-#include "tbb/concurrent_vector.h"
-#include "tbb/tbb_allocator.h"
+#include <tbb/blocked_range.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/tbb_allocator.h>
 
-#include "header/defines.h"
-#include "header/tree.h"
-#include "header/vector_types.h"
-#include "header/vector_math.h"
-#include "header/costs.h"
-#include "header/tree_optimizer.h"
-#include "header/parallel_templates.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/tree.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/vector_math.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/tree_optimizer.h>
+#include <mapmap/header/parallel_templates.h>
 
-#include "header/optimizer_instances/dp_node.h"
+#include <mapmap/header/optimizer_instances/dp_node.h>
 
 NS_MAPMAP_BEGIN
 
@@ -109,6 +109,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/dynamic_programming.impl.h"
+#include <mapmap/source/optimizer_instances/dynamic_programming.impl.h>
 
 #endif /* __MAPMAP_DYNAMIC_PROGRAMMING_H_ */

--- a/mapmap/header/optimizer_instances/envelope.h
+++ b/mapmap/header/optimizer_instances/envelope.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_ENVELOPE_H_
 #define __MAPMAP_ENVELOPE_H_
 
-#include "header/optimizer_instances/dp_node.h"
+#include <mapmap/header/optimizer_instances/dp_node.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/header/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.h
+++ b/mapmap/header/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.h
@@ -10,9 +10,9 @@
 #ifndef __MAPMAP_PAIRWISE_ANTIPOTTS_ENVELOPE_H_
 #define __MAPMAP_PAIRWISE_ANTIPOTTS_ENVELOPE_H_
 
-#include "header/defines.h"
-#include "header/optimizer_instances/envelope.h"
-#include "header/cost_instances/pairwise_antipotts.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/optimizer_instances/envelope.h>
+#include <mapmap/header/cost_instances/pairwise_antipotts.h>
 
 NS_MAPMAP_BEGIN
 
@@ -48,6 +48,6 @@ using PairwiseAntipottsEnvelope_ptr = std::unique_ptr<PairwiseAntipottsEnvelope<
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.impl.h"
+#include <mapmap/source/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.impl.h>
 
 #endif /* __MAPMAP_AIRWISE_ANTIPOTTS_ENVELOPE_H_ */

--- a/mapmap/header/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.h
+++ b/mapmap/header/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.h
@@ -10,9 +10,9 @@
 #ifndef __MAPMAP_PAIRWISE_LINEAR_PEAK_ENVELOPE_H_
 #define __MAPMAP_PAIRWISE_LINEAR_PEAK_ENVELOPE_H_
 
-#include "header/defines.h"
-#include "header/optimizer_instances/envelope.h"
-#include "header/cost_instances/pairwise_truncated_linear.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/optimizer_instances/envelope.h>
+#include <mapmap/header/cost_instances/pairwise_truncated_linear.h>
 
 NS_MAPMAP_BEGIN
 
@@ -49,6 +49,6 @@ using PairwiseLinearPeakEnvelope_ptr =
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.impl.h"
+#include <mapmap/source/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_LINEAR_PEAK_ENVELOPE_H_ */

--- a/mapmap/header/optimizer_instances/envelope_instances/pairwise_potts_envelope.h
+++ b/mapmap/header/optimizer_instances/envelope_instances/pairwise_potts_envelope.h
@@ -10,9 +10,9 @@
 #ifndef __MAPMAP_PAIRWISE_POTTS_ENVELOPE_H_
 #define __MAPMAP_PAIRWISE_POTTS_ENVELOPE_H_
 
-#include "header/defines.h"
-#include "header/optimizer_instances/envelope.h"
-#include "header/cost_instances/pairwise_potts.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/optimizer_instances/envelope.h>
+#include <mapmap/header/cost_instances/pairwise_potts.h>
 
 NS_MAPMAP_BEGIN
 
@@ -47,6 +47,6 @@ using PairwisePottsEnvelope_ptr = std::unique_ptr<PairwisePottsEnvelope<
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/envelope_instances/pairwise_potts_envelope.impl.h"
+#include <mapmap/source/optimizer_instances/envelope_instances/pairwise_potts_envelope.impl.h>
 
 #endif /* __MAPMAP_AIRWISE_POTTS_ENVELOPE_H_ */

--- a/mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.h
+++ b/mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.h
@@ -10,9 +10,9 @@
 #ifndef __MAPMAP_PAIRWISE_TRUNCATED_LINEAR_ENVELOPE_H_
 #define __MAPMAP_PAIRWISE_TRUNCATED_LINEAR_ENVELOPE_H_
 
-#include "header/defines.h"
-#include "header/optimizer_instances/envelope.h"
-#include "header/cost_instances/pairwise_truncated_linear.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/optimizer_instances/envelope.h>
+#include <mapmap/header/cost_instances/pairwise_truncated_linear.h>
 
 NS_MAPMAP_BEGIN
 
@@ -49,6 +49,6 @@ using PairwiseTruncatedLinearEnvelope_ptr =
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.impl.h"
+#include <mapmap/source/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_TRUNCATED_LINEAR_ENVELOPE_H_ */

--- a/mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.h
+++ b/mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.h
@@ -10,9 +10,9 @@
 #ifndef __MAPMAP_PAIRWISE_TRUNCATED_QUADRATIC_ENVELOPE_H_
 #define __MAPMAP_PAIRWISE_TRUNCATED_QUADRATIC_ENVELOPE_H_
 
-#include "header/defines.h"
-#include "header/optimizer_instances/envelope.h"
-#include "header/cost_instances/pairwise_truncated_quadratic.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/optimizer_instances/envelope.h>
+#include <mapmap/header/cost_instances/pairwise_truncated_quadratic.h>
 
 NS_MAPMAP_BEGIN
 
@@ -49,6 +49,6 @@ using PairwiseTruncatedQuadraticEnvelope_ptr =
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.impl.h"
+#include <mapmap/source/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.impl.h>
 
 #endif /* __MAPMAP_PAIRWISE_TRUNCATED_QUADRATIC_ENVELOPE_H_ */

--- a/mapmap/header/parallel_templates.h
+++ b/mapmap/header/parallel_templates.h
@@ -18,8 +18,8 @@
 #include <tbb/blocked_range.h>
 #include <tbb/atomic.h>
 
-#include "header/defines.h"
-#include "header/vector_types.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
 
 NS_MAPMAP_BEGIN
 
@@ -112,6 +112,6 @@ protected:
 NS_MAPMAP_END
 
 /* include templated implementation */
-#include "source/parallel_templates.impl.h"
+#include <mapmap/source/parallel_templates.impl.h>
 
 #endif /* __MAPMAP_PARALLEL_TEMPLATES_H_ */

--- a/mapmap/header/termination_criterion.h
+++ b/mapmap/header/termination_criterion.h
@@ -13,9 +13,9 @@
 #include <vector>
 #include <memory>
 
-#include "header/defines.h"
-#include "header/vector_types.h"
-#include "header/vector_math.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/vector_math.h>
 
 NS_MAPMAP_BEGIN
 
@@ -63,6 +63,6 @@ public:
 
 NS_MAPMAP_END
 
-#include "source/termination_criterion.impl.h"
+#include <mapmap/source/termination_criterion.impl.h>
 
 #endif /* __MAPMAP_TERMINATION_CRITERION_H_ */

--- a/mapmap/header/termination_instances/stop_after_iterations.h
+++ b/mapmap/header/termination_instances/stop_after_iterations.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_STOP_AFTER_ITERATIONS_H_
 #define __MAPMAP_STOP_AFTER_ITERATIONS_H_
 
-#include "header/termination_criterion.h"
+#include <mapmap/header/termination_criterion.h>
 
 NS_MAPMAP_BEGIN
 
@@ -38,6 +38,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/termination_instances/stop_after_iterations.impl.h"
+#include <mapmap/source/termination_instances/stop_after_iterations.impl.h>
 
 #endif /* __MAPMAP_STOP_AFTER_ITERATIONS_H_ */

--- a/mapmap/header/termination_instances/stop_after_time.h
+++ b/mapmap/header/termination_instances/stop_after_time.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_STOP_AFTER_TIME_H_
 #define __MAPMAP_STOP_AFTER_TIME_H_
 
-#include "header/termination_criterion.h"
+#include <mapmap/header/termination_criterion.h>
 
 NS_MAPMAP_BEGIN
 
@@ -33,6 +33,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/termination_instances/stop_after_time.impl.h"
+#include <mapmap/source/termination_instances/stop_after_time.impl.h>
 
 #endif /* __MAPMAP_STOP_AFTER_TIME_H_ */

--- a/mapmap/header/termination_instances/stop_when_flat.h
+++ b/mapmap/header/termination_instances/stop_when_flat.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_STOP_WHEN_FLAT_H_
 #define __MAPMAP_STOP_WHEN_FLAT_H_
 
-#include "header/termination_criterion.h"
+#include <mapmap/header/termination_criterion.h>
 
 NS_MAPMAP_BEGIN
 
@@ -33,6 +33,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/termination_instances/stop_when_flat.impl.h"
+#include <mapmap/source/termination_instances/stop_when_flat.impl.h>
 
 #endif /* __MAPMAP_STOP_WHEN_FLAT_H_ */

--- a/mapmap/header/termination_instances/stop_when_returns_diminish.h
+++ b/mapmap/header/termination_instances/stop_when_returns_diminish.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_STOP_WHEN_RETURNS_DIMINISH_H_
 #define __MAPMAP_STOP_WHEN_RETURNS_DIMINISH_H_
 
-#include "header/termination_criterion.h"
+#include <mapmap/header/termination_criterion.h>
 
 NS_MAPMAP_BEGIN
 
@@ -32,6 +32,6 @@ protected:
 
 NS_MAPMAP_END
 
-#include "source/termination_instances/stop_when_returns_diminish.impl.h"
+#include <mapmap/source/termination_instances/stop_when_returns_diminish.impl.h>
 
 #endif /* __MAPMAP_STOP_WHEN_RETURNS_DIMINISH_H_ */

--- a/mapmap/header/timer.h
+++ b/mapmap/header/timer.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_TIMER_H_
 #define __MAPMAP_TIMER_H_
 
-#include "header/defines.h"
+#include <mapmap/header/defines.h>
 
 NS_MAPMAP_BEGIN
 
@@ -38,6 +38,6 @@ extern _timer * __T;
 NS_MAPMAP_END
 
 /* include timer implementation */
-#include "source/timer.impl.h"
+#include <mapmap/source/timer.impl.h>
 
 #endif /* __MAPMAP_TIMER_H_ */

--- a/mapmap/header/tree.h
+++ b/mapmap/header/tree.h
@@ -14,9 +14,9 @@
 #include <vector>
 #include <iterator>
 
-#include "header/defines.h"
-#include "header/vector_types.h"
-#include "header/graph.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/graph.h>
 
 NS_MAPMAP_BEGIN
 
@@ -118,6 +118,6 @@ protected:
 
 NS_MAPMAP_END
 
-#include "source/tree.impl.h"
+#include <mapmap/source/tree.impl.h>
 
 #endif /* __MAPMAP_TREE_H_ */

--- a/mapmap/header/tree_optimizer.h
+++ b/mapmap/header/tree_optimizer.h
@@ -13,12 +13,12 @@
 #include <memory>
 #include <vector>
 
-#include "header/defines.h"
-#include "header/tree.h"
-#include "header/vector_types.h"
-#include "header/costs.h"
-#include "header/cost_bundle.h"
-#include "header/graph.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/tree.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/cost_bundle.h>
+#include <mapmap/header/graph.h>
 
 NS_MAPMAP_BEGIN
 
@@ -67,6 +67,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/tree_optimizer.impl.h"
+#include <mapmap/source/tree_optimizer.impl.h>
 
 #endif /* __MAPMAP_TREE_OPTIMIZER_H_ */

--- a/mapmap/header/tree_sampler.h
+++ b/mapmap/header/tree_sampler.h
@@ -10,8 +10,8 @@
 #ifndef __MAPMAP_TREE_SAMPLER_H_
 #define __MAPMAP_TREE_SAMPLER_H_
 
-#include "header/defines.h"
-#include "header/tree.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/tree.h>
 
 #include <random>
 
@@ -53,6 +53,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/tree_sampler.impl.h"
+#include <mapmap/source/tree_sampler.impl.h>
 
 #endif /* __MAPMAP_TREE_SAMPLER_H_ */

--- a/mapmap/header/tree_sampler_instances/lock_free_tree_sampler.h
+++ b/mapmap/header/tree_sampler_instances/lock_free_tree_sampler.h
@@ -10,13 +10,13 @@
 #ifndef __MAPMAP_LOCK_FREE_TREE_SAMPLER_H_
 #define __MAPMAP_LOCK_FREE_TREE_SAMPLER_H_
 
-#include "header/defines.h"
-#include "header/graph.h"
-#include "header/tree.h"
-#include "header/tree_sampler.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/graph.h>
+#include <mapmap/header/tree.h>
+#include <mapmap/header/tree_sampler.h>
 
-#include "tbb/atomic.h"
-#include "tbb/concurrent_vector.h"
+#include <tbb/atomic.h>
+#include <tbb/concurrent_vector.h>
 
 NS_MAPMAP_BEGIN
 
@@ -133,6 +133,6 @@ protected:
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/tree_sampler_instances/lock_free_tree_sampler.impl.h"
+#include <mapmap/source/tree_sampler_instances/lock_free_tree_sampler.impl.h>
 
 #endif /* __MAPMAP_LOCK_FREE_TREE_SAMPLER_H_ */

--- a/mapmap/header/tree_sampler_instances/optimistic_tree_sampler.h
+++ b/mapmap/header/tree_sampler_instances/optimistic_tree_sampler.h
@@ -14,13 +14,13 @@
 #include <memory>
 #include <random>
 
-#include "tbb/concurrent_vector.h"
+#include <tbb/concurrent_vector.h>
 
-#include "header/defines.h"
-#include "header/graph.h"
-#include "header/tree.h"
-#include "header/vector_types.h"
-#include "header/tree_sampler.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/graph.h>
+#include <mapmap/header/tree.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/tree_sampler.h>
 
 NS_MAPMAP_BEGIN
 
@@ -103,6 +103,6 @@ using OptimisticTreeSampler_ptr =
 NS_MAPMAP_END
 
 /* include function implementations */
-#include "source/tree_sampler_instances/optimistic_tree_sampler.impl.h"
+#include <mapmap/source/tree_sampler_instances/optimistic_tree_sampler.impl.h>
 
 #endif /* __MAPMAP_HEADER_OPTIMISTIC_TREE_SAMPLER_H_ */

--- a/mapmap/header/vector_math.h
+++ b/mapmap/header/vector_math.h
@@ -14,8 +14,8 @@
 #include <cstdio>
 #include <cstring>
 
-#include "header/defines.h"
-#include "header/vector_types.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
 
 NS_MAPMAP_BEGIN
 
@@ -351,6 +351,6 @@ v_alignment();
 
 NS_MAPMAP_END 
 
-#include "source/vector_math.impl.h"
+#include <mapmap/source/vector_math.impl.h>
  
 #endif /* MAPMAP_HEADER_VECTOR_MATH_H_ */

--- a/mapmap/header/vector_types.h
+++ b/mapmap/header/vector_types.h
@@ -12,7 +12,7 @@
 
 #include <cstdint>
 
-#include "header/defines.h"
+#include <mapmap/header/defines.h>
 
 #if defined(__SSE4_2__)
     #include <smmintrin.h>  

--- a/mapmap/source/color.impl.h
+++ b/mapmap/source/color.impl.h
@@ -7,14 +7,14 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/color.h"
+#include <mapmap/header/color.h>
 
 #include <algorithm>
 
-#include "tbb/atomic.h"
-#include "tbb/parallel_reduce.h"
-#include "tbb/parallel_for.h"
-#include "tbb/mutex.h"
+#include <tbb/atomic.h>
+#include <tbb/parallel_reduce.h>
+#include <tbb/parallel_for.h>
+#include <tbb/mutex.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_bundle.impl.h
+++ b/mapmap/source/cost_bundle.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/cost_bundle.h"
+#include <mapmap/header/cost_bundle.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_instances/pairwise_antipotts.impl.h
+++ b/mapmap/source/cost_instances/pairwise_antipotts.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/cost_instances/pairwise_antipotts.h"
+#include <mapmap/header/cost_instances/pairwise_antipotts.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_instances/pairwise_linear_peak.impl.h
+++ b/mapmap/source/cost_instances/pairwise_linear_peak.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/cost_instances/pairwise_linear_peak.h"
+#include <mapmap/header/cost_instances/pairwise_linear_peak.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_instances/pairwise_potts.impl.h
+++ b/mapmap/source/cost_instances/pairwise_potts.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/cost_instances/pairwise_potts.h"
+#include <mapmap/header/cost_instances/pairwise_potts.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_instances/pairwise_table.impl.h
+++ b/mapmap/source/cost_instances/pairwise_table.impl.h
@@ -7,12 +7,12 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/cost_instances/pairwise_table.h"
+#include <mapmap/header/cost_instances/pairwise_table.h>
 
 #include <limits>
 #include <iostream>
 
-#include "header/parallel_templates.h"
+#include <mapmap/header/parallel_templates.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_instances/pairwise_truncated_linear.impl.h
+++ b/mapmap/source/cost_instances/pairwise_truncated_linear.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/cost_instances/pairwise_truncated_linear.h"
+#include <mapmap/header/cost_instances/pairwise_truncated_linear.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_instances/pairwise_truncated_quadratic.impl.h
+++ b/mapmap/source/cost_instances/pairwise_truncated_quadratic.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/cost_instances/pairwise_truncated_quadratic.h"
+#include <mapmap/header/cost_instances/pairwise_truncated_quadratic.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/cost_instances/unary_table.impl.h
+++ b/mapmap/source/cost_instances/unary_table.impl.h
@@ -11,13 +11,13 @@
 #include <cassert>
 #include <iostream>
 
-#include "tbb/parallel_for.h"
-#include "tbb/blocked_range.h"
-#include "tbb/parallel_scan.h"
-#include "tbb/parallel_do.h"
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_scan.h>
+#include <tbb/parallel_do.h>
 
-#include "header/cost_instances/unary_table.h"
-#include "header/parallel_templates.h"
+#include <mapmap/header/cost_instances/unary_table.h>
+#include <mapmap/header/parallel_templates.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/costs.impl.h
+++ b/mapmap/source/costs.impl.h
@@ -12,11 +12,11 @@
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
 
-#include "header/costs.h"
+#include <mapmap/header/costs.h>
 
-#include "header/defines.h"
-#include "header/vector_types.h"
-#include "header/vector_math.h"
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
+#include <mapmap/header/vector_math.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/dynamic_programming.impl.h
+++ b/mapmap/source/dynamic_programming.impl.h
@@ -11,10 +11,10 @@
 #include <functional>
 #include <iostream>
 
-#include "tbb/tbb.h"
+#include <tbb/tbb.h>
 
 
-#include "header/dynamic_programming.h"
+#include <mapmap/header/dynamic_programming.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/graph.impl.h
+++ b/mapmap/source/graph.impl.h
@@ -17,17 +17,17 @@
 #include <algorithm>
 #include <random>
 
-#include "tbb/concurrent_queue.h"
-#include "tbb/concurrent_vector.h"
-#include "tbb/concurrent_unordered_set.h"
-#include "tbb/atomic.h"
-#include "tbb/task.h"
-#include "tbb/blocked_range.h"
-#include "tbb/parallel_for.h"
+#include <tbb/concurrent_queue.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/concurrent_unordered_set.h>
+#include <tbb/atomic.h>
+#include <tbb/task.h>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
 
-#include "header/graph.h"
+#include <mapmap/header/graph.h>
 
-#include "dset.h"
+#include <mapmap/dset.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/instance_factory.impl.h
+++ b/mapmap/source/instance_factory.impl.h
@@ -7,10 +7,10 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/instance_factory.h"
+#include <mapmap/header/instance_factory.h>
 
-#include "header/tree_sampler_instances/optimistic_tree_sampler.h"
-#include "header/tree_sampler_instances/lock_free_tree_sampler.h"
+#include <mapmap/header/tree_sampler_instances/optimistic_tree_sampler.h>
+#include <mapmap/header/tree_sampler_instances/lock_free_tree_sampler.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/mapmap.impl.h
+++ b/mapmap/source/mapmap.impl.h
@@ -7,14 +7,14 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/mapmap.h"
+#include <mapmap/header/mapmap.h>
 
 #include <iostream>
 
-#include "header/multilevel_instances/group_same_label.h"
-#include "header/termination_instances/stop_when_flat.h"
-#include "header/optimizer_instances/dynamic_programming.h"
-#include "header/timer.h"
+#include <mapmap/header/multilevel_instances/group_same_label.h>
+#include <mapmap/header/termination_instances/stop_when_flat.h>
+#include <mapmap/header/optimizer_instances/dynamic_programming.h>
+#include <mapmap/header/timer.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/multilevel.impl.h
+++ b/mapmap/source/multilevel.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/multilevel.h"
+#include <mapmap/header/multilevel.h>
 
 #include <stdexcept>
 #include <utility>
@@ -15,15 +15,15 @@
 #include <set>
 #include <iostream>
 
-#include "tbb/parallel_for.h"
-#include "tbb/blocked_range.h"
-#include "tbb/concurrent_vector.h"
-#include "tbb/atomic.h"
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/atomic.h>
 
-#include "header/parallel_templates.h"
-#include "header/costs.h"
-#include "header/cost_instances/unary_table.h"
-#include "header/cost_instances/pairwise_table.h"
+#include <mapmap/header/parallel_templates.h>
+#include <mapmap/header/costs.h>
+#include <mapmap/header/cost_instances/unary_table.h>
+#include <mapmap/header/cost_instances/pairwise_table.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/multilevel_instances/group_same_label.impl.h
+++ b/mapmap/source/multilevel_instances/group_same_label.impl.h
@@ -7,16 +7,16 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/multilevel_instances/group_same_label.h"
+#include <mapmap/header/multilevel_instances/group_same_label.h>
 
 #include <algorithm>
 #include <queue>
 #include <iostream>
 
-#include "tbb/atomic.h"
-#include "tbb/blocked_range.h"
-#include "tbb/parallel_for.h"
-#include "tbb/parallel_do.h"
+#include <tbb/atomic.h>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_do.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/optimizer_instances/dp_node_solver.impl.h
+++ b/mapmap/source/optimizer_instances/dp_node_solver.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/optimizer_instances/dp_node_solver.h"
+#include <mapmap/header/optimizer_instances/dp_node_solver.h>
 
 #include <limits>
 

--- a/mapmap/source/optimizer_instances/dp_node_solver_factory.impl.h
+++ b/mapmap/source/optimizer_instances/dp_node_solver_factory.impl.h
@@ -7,24 +7,24 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/optimizer_instances/dp_node_solver_factory.h"
+#include <mapmap/header/optimizer_instances/dp_node_solver_factory.h>
 
-#include "header/cost_instances/unary_table.h"
+#include <mapmap/header/cost_instances/unary_table.h>
 
-#include "header/cost_instances/pairwise_antipotts.h"
-#include "header/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.h"
+#include <mapmap/header/cost_instances/pairwise_antipotts.h>
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.h>
 
-#include "header/cost_instances/pairwise_linear_peak.h"
-#include "header/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.h"
+#include <mapmap/header/cost_instances/pairwise_linear_peak.h>
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.h>
 
-#include "header/cost_instances/pairwise_potts.h"
-#include "header/optimizer_instances/envelope_instances/pairwise_potts_envelope.h"
+#include <mapmap/header/cost_instances/pairwise_potts.h>
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_potts_envelope.h>
 
-#include "header/cost_instances/pairwise_truncated_linear.h"
-#include "header/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.h"
+#include <mapmap/header/cost_instances/pairwise_truncated_linear.h>
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.h>
 
-#include "header/cost_instances/pairwise_truncated_quadratic.h"
-#include "header/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.h"
+#include <mapmap/header/cost_instances/pairwise_truncated_quadratic.h>
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/optimizer_instances/dynamic_programming.impl.h
+++ b/mapmap/source/optimizer_instances/dynamic_programming.impl.h
@@ -11,11 +11,11 @@
 #include <functional>
 #include <iostream>
 
-#include "tbb/tbb.h"
+#include <tbb/tbb.h>
 
-#include "header/optimizer_instances/dynamic_programming.h"
-#include "header/optimizer_instances/dp_node.h"
-#include "header/optimizer_instances/dp_node_solver_factory.h"
+#include <mapmap/header/optimizer_instances/dynamic_programming.h>
+#include <mapmap/header/optimizer_instances/dp_node.h>
+#include <mapmap/header/optimizer_instances/dp_node_solver_factory.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.impl.h
+++ b/mapmap/source/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.h"
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_antipotts_envelope.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.impl.h
+++ b/mapmap/source/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.h"
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_linear_peak_envelope.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/optimizer_instances/envelope_instances/pairwise_potts_envelope.impl.h
+++ b/mapmap/source/optimizer_instances/envelope_instances/pairwise_potts_envelope.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/optimizer_instances/envelope_instances/pairwise_potts_envelope.h"
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_potts_envelope.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.impl.h
+++ b/mapmap/source/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.h"
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_linear_envelope.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.impl.h
+++ b/mapmap/source/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.h"
+#include <mapmap/header/optimizer_instances/envelope_instances/pairwise_truncated_quadratic_envelope.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/parallel_templates.impl.h
+++ b/mapmap/source/parallel_templates.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/parallel_templates.h"
+#include <mapmap/header/parallel_templates.h>
 
 #include <limits>
 

--- a/mapmap/source/termination_criterion.impl.h
+++ b/mapmap/source/termination_criterion.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/termination_criterion.h"
+#include <mapmap/header/termination_criterion.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/termination_instances/stop_after_iterations.impl.h
+++ b/mapmap/source/termination_instances/stop_after_iterations.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/termination_instances/stop_after_iterations.h"
+#include <mapmap/header/termination_instances/stop_after_iterations.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/termination_instances/stop_after_time.impl.h
+++ b/mapmap/source/termination_instances/stop_after_time.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/termination_instances/stop_after_time.h"
+#include <mapmap/header/termination_instances/stop_after_time.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/termination_instances/stop_when_flat.impl.h
+++ b/mapmap/source/termination_instances/stop_when_flat.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/termination_instances/stop_when_flat.h"
+#include <mapmap/header/termination_instances/stop_when_flat.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/termination_instances/stop_when_returns_diminish.impl.h
+++ b/mapmap/source/termination_instances/stop_when_returns_diminish.impl.h
@@ -10,7 +10,7 @@
 #ifndef __MAPMAP_HEADER_TERMINATION_INSTANCES_STOP_WHEN_RETURNS_DIMINISH_IMPL_H_
 #define __MAPMAP_HEADER_TERMINATION_INSTANCES_STOP_WHEN_RETURNS_DIMINISH_IMPL_H_
 
-#include "header/termination_instances/stop_when_returns_diminish.h"
+#include <mapmap/header/termination_instances/stop_when_returns_diminish.h>
 
 #include <iostream>
 

--- a/mapmap/source/timer.impl.h
+++ b/mapmap/source/timer.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/timer.h"
+#include <mapmap/header/timer.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/tree.impl.h
+++ b/mapmap/source/tree.impl.h
@@ -7,19 +7,19 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/tree.h"
+#include <mapmap/header/tree.h>
 
 #include <exception>
 #include <functional>
 #include <numeric>
 #include <iostream>
 
-#include "tbb/parallel_for.h"
-#include "tbb/blocked_range.h"
-#include "tbb/parallel_reduce.h"
-#include "tbb/parallel_scan.h"
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_reduce.h>
+#include <tbb/parallel_scan.h>
 
-#include "header/parallel_templates.h"
+#include <mapmap/header/parallel_templates.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/tree_optimizer.impl.h
+++ b/mapmap/source/tree_optimizer.impl.h
@@ -6,10 +6,10 @@
  * This software may be modified and distributed under the terms
  * of the BSD license. See the LICENSE file for details.
  */
-#include "header/tree_optimizer.h"
+#include <mapmap/header/tree_optimizer.h>
 
-#include "tbb/blocked_range.h"
-#include "tbb/parallel_reduce.h"
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_reduce.h>
 
 #include <iostream>
 

--- a/mapmap/source/tree_sampler.impl.h
+++ b/mapmap/source/tree_sampler.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/tree_sampler.h"
+#include <mapmap/header/tree_sampler.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/tree_sampler_instances/lock_free_tree_sampler.impl.h
+++ b/mapmap/source/tree_sampler_instances/lock_free_tree_sampler.impl.h
@@ -7,17 +7,17 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/tree_sampler_instances/lock_free_tree_sampler.h"
+#include <mapmap/header/tree_sampler_instances/lock_free_tree_sampler.h>
 
-#include "header/color.h"
+#include <mapmap/header/color.h>
 
 #include <random>
 #include <set>
 #include <algorithm>
 
-#include "tbb/parallel_reduce.h"
-#include "tbb/parallel_for.h"
-#include "tbb/blocked_range.h"
+#include <tbb/parallel_reduce.h>
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/tree_sampler_instances/optimistic_tree_sampler.impl.h
+++ b/mapmap/source/tree_sampler_instances/optimistic_tree_sampler.impl.h
@@ -7,15 +7,15 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#include "header/tree_sampler_instances/optimistic_tree_sampler.h"
+#include <mapmap/header/tree_sampler_instances/optimistic_tree_sampler.h>
 
 #include <iostream>
 
-#include "tbb/blocked_range.h"
-#include "tbb/parallel_for.h"
-#include "tbb/parallel_do.h"
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_do.h>
 
-#include "header/parallel_templates.h"
+#include <mapmap/header/parallel_templates.h>
 
 NS_MAPMAP_BEGIN
 

--- a/mapmap/source/vector_math.impl.h
+++ b/mapmap/source/vector_math.impl.h
@@ -7,7 +7,7 @@
  * of the BSD license. See the LICENSE file for details.
  */
  
-#include "header/vector_math.h"
+#include <mapmap/header/vector_math.h>
 
 #include <cstring>
 #include <algorithm>


### PR DESCRIPTION
Fixes a few identified problem when building this library with Visual Studio 2019

- std::max conflicts with macro max, define WIN32_LEAN_AND_MEAN and NOMINMAX to avoid this problem
- add a missing include directive
- std::random_shuffle is deprecated in C++14 and removed in C++17. Replace it by std::shuffle
