### PR TITLE
Building mapmap_cpu with tipi.build source scan

### DIFF
--- a/.github/workflows/tipi.yml
+++ b/.github/workflows/tipi.yml
@@ -1,0 +1,17 @@
+name: tipi.build 
+# This workflow is triggered on pushes to the repository.
+on: [push]
+
+jobs:
+  build: 
+    name: build-linux
+    runs-on: ubuntu-latest
+    container: tipibuild/tipi-ubuntu
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: tipi builds project 
+        run: |
+          export HOME=/root
+          mkdir -p ~/.tipi
+          tipi . -t linux --dont-upgrade --verbose --test all 

--- a/.github/workflows/tipi.yml
+++ b/.github/workflows/tipi.yml
@@ -14,4 +14,8 @@ jobs:
         run: |
           export HOME=/root
           mkdir -p ~/.tipi
+
+          mkdir -p build/linux/bin/demo \
+            && curl http://download.hrz.tu-darmstadt.de/media/FB20/GCC/project_files/mapmap/planesweep_320_256_96.bin --output build/linux/bin/demo/planesweep_320_256_96.bin          
+
           tipi . -t linux --dont-upgrade --verbose --test all 

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,0 +1,4 @@
+{
+  "google/googletest": { "u": true, "packages": ["GTest"], "targets": ["GTest::gtest", "GTest::gmock"] }
+  ,  "oneapi-src/oneTBB" : { "@" : "v2021.5.0" , "u" : true, "packages": ["TBB"], "targets": ["TBB::tbb", "TBB::tbbmalloc"] }
+}

--- a/.tipi/opts
+++ b/.tipi/opts
@@ -1,0 +1,2 @@
+set (TBB_TEST OFF CACHE BOOL "")
+add_compile_definitions(BUILD_FOR_TEST)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ In the future, we will add:
 
 For the license and terms of usage, please see "License, Terms of usage & Reference".
 
+Quickstart with tipi.build
+------
+All prerequisites are provided by tipi.build and the `.tipi/deps` file, to compile this project simply run : 
+```
+tipi . -t <platform>
+```
+Where platform is either one of linux, windows, macos or any of the supported environments.
+
 Prerequisites
 ------
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,6 @@
 mapMAP MRF MAP Solver [![Build Status](https://github.com/dthuerck/mapmap_cpu/actions/workflows/master.yml/badge.svg)](https://github.com/dthuerck/mapmap_cpu/actions)
 ======
 
-Change Log
-------
-Compared with the development version from our HPG paper (cf. below).
-
-* v1.5 (6/25/2018):
-  - Added tech report for new tree selection algorithm (from v1.2) in doc/.
-  - Added novel envelopes for supermodular cost function types ("Antipotts",
-    "LinearPeak"). A tech report _may_ follow.
-  - Several bugfixes.
-* v1.4 (1/10/2018):
-  - Deterministic solver path with user-provided seed.
-  - Several bugfixes and smaller improvements.
-* v1.3 (10/18/2017):
-  - Envelope optimization for Potts, TruncatedLinear, TruncatedQuadratic.
-  - Ability to have individual cost functions per edge.
-  - Removed UNARY/PAIRWISE template parameters from solver, hiding these
-    internally.
-  - Improved multilevel performance, even in the case of individual costs.
-  - Added GTest for automatic built instead of a hard dependency.
-* v1.2 (5/29/2017):
-  - Introduced a new, multicoloring-based tree selection algorithm -
-    lock-free.
-* v1.1 (4/12/2017):
-  - Tuned the tree growing implementation for early termination and
-  - option for relaxing the maximality requirement.
-* v1.0 (2/8/2017):
-  - Stable release.
-  - Logging callbacks for use as library.
-  - Clean, documented interface and documentation.
-  - Added a demo for correct usage.
-* beta (12/6/2016):
-  - Initial release, mirrors functionality outlined in the paper.
-  - Automated vectorization (compile-time detection) for float/double.
-  - Supporting scalar/SSE2-4/AVX/AVX2.
-  - Added cost function instances.
-  - Added unit tests.
-
 Overview
 ------
 
@@ -74,36 +37,15 @@ Currently, this code implements the following modules and features:
 - [x] Finding and exploiting connected components in the topology
 - [x] Test suite for each individual module
 
-In the future, we will add:
+What it lacks:
 - [ ] Capability to process label costs as outlined in the paper
 
 For the license and terms of usage, please see "License, Terms of usage & Reference".
 
-Quickstart with tipi.build
-------
-All prerequisites are provided by tipi.build and the `.tipi/deps` file, to compile this project simply run : 
-```
-tipi . -t <platform>
-```
-Where platform is either one of linux, windows, macos or any of the supported environments.
-
-Using mapMAP in your project with tipi.build 
-------
-
-`mapMAP` can be easily used with the [tipi.build](https://tipi.build) dependency manager, by adding the following to a `.tipi/deps`:
-
-```json
-{
-    "dthuerck/mapmap_cpu": { }
-}
-```
-
-An example to start with is available in [example-mapmap_cpu](https://github.com/tipi-deps/example-mapmap_cpu) (change the target name appropriately to `linux` or `macos` or `windows`):
-
-```bash
-tipi . -t <target>
-```
-
+In addition to a "classical", CMake-based workflow, the great folks at [`tipi.build`](https://tipi.build/)
+contributed (optional) support for their C++ build and dependency manager. With `tipi`,
+building `mapmap` or using it as a library in your own projects just happens
+by a snap of your finger.
 
 Prerequisites
 ------
@@ -131,6 +73,8 @@ Quickstart
 The following instructions are provided for linux; the Windows workflow
 should be somewhat similar, though GUI-based.
 
+#### The classical way
+
 *Step-by-step* instructions:
 
 1. `git clone https://github.com/dthuerck/mapmap_cpu`
@@ -154,8 +98,18 @@ should be somewhat similar, though GUI-based.
 6. Depending on your configuration, you can now run `mapmap_test` and/or
    `mapmap_demo` (assuming you activated `BUILD_TEST` and `BUILD_DEMO`).
 
+#### Using `tipi.build`
+
+All prerequisites are provided by tipi.build and the `.tipi/deps` file, to compile this project simply run : 
+```
+tipi . -t <platform>
+```
+Where platform is either one of linux, windows, macos or any of the supported environments.
+
 Using mapMAP as a library in your own projects
 ------
+
+#### The classical way
 
 mapMAP is implemented as a templated, header only library. A simple
 ```
@@ -173,12 +127,29 @@ performance:
 As a good starting point, we recommend studying `mapmap_demo.cc` closely,
 which is mostly self-explanatory.
 
+#### Using `tipi.build`
+
+`mapMAP` can be easily used with the [tipi.build](https://tipi.build) dependency manager, by adding the following to a `.tipi/deps`:
+
+```json
+{
+    "dthuerck/mapmap_cpu": { }
+}
+```
+
 Documentation
 ------
 
 For extended documentation on building, using and extending mapMAP, please
 see the
 [integrated wiki](https://github.com/dthuerck/mapmap_cpu/wiki).
+```
+
+An example to start with is available in [example-mapmap_cpu](https://github.com/tipi-deps/example-mapmap_cpu) (change the target name appropriately to `linux` or `macos` or `windows`):
+
+```bash
+tipi . -t <target>
+```
 
 License, Terms of Usage & Reference
 ------
@@ -206,3 +177,41 @@ Contact
 For any trouble with building, using or extending this software, please use
 the project's integrated issue tracker. We'll be happy to help you there or
 discuss feature requests.
+
+
+Change Log
+------
+Compared with the development version from our HPG paper (cf. below).
+
+* v1.5 (6/25/2018):
+  - Added tech report for new tree selection algorithm (from v1.2) in doc/.
+  - Added novel envelopes for supermodular cost function types ("Antipotts",
+    "LinearPeak"). A tech report _may_ follow.
+  - Several bugfixes.
+* v1.4 (1/10/2018):
+  - Deterministic solver path with user-provided seed.
+  - Several bugfixes and smaller improvements.
+* v1.3 (10/18/2017):
+  - Envelope optimization for Potts, TruncatedLinear, TruncatedQuadratic.
+  - Ability to have individual cost functions per edge.
+  - Removed UNARY/PAIRWISE template parameters from solver, hiding these
+    internally.
+  - Improved multilevel performance, even in the case of individual costs.
+  - Added GTest for automatic built instead of a hard dependency.
+* v1.2 (5/29/2017):
+  - Introduced a new, multicoloring-based tree selection algorithm -
+    lock-free.
+* v1.1 (4/12/2017):
+  - Tuned the tree growing implementation for early termination and
+  - option for relaxing the maximality requirement.
+* v1.0 (2/8/2017):
+  - Stable release.
+  - Logging callbacks for use as library.
+  - Clean, documented interface and documentation.
+  - Added a demo for correct usage.
+* beta (12/6/2016):
+  - Initial release, mirrors functionality outlined in the paper.
+  - Automated vectorization (compile-time detection) for float/double.
+  - Supporting scalar/SSE2-4/AVX/AVX2.
+  - Added cost function instances.
+  - Added unit tests.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ tipi . -t <platform>
 ```
 Where platform is either one of linux, windows, macos or any of the supported environments.
 
+Using mapMAP in your project with tipi.build 
+------
+
+`mapMAP` can be easily used with the [tipi.build](https://tipi.build) dependency manager, by adding the following to a `.tipi/deps`:
+
+```json
+{
+    "dthuerck/mapmap_cpu": { }
+}
+```
+
+An example to start with is available in [example-mapmap_cpu](https://github.com/tipi-deps/example-mapmap_cpu) (change the target name appropriately to `linux` or `macos` or `windows`):
+
+```bash
+tipi . -t <target>
+```
+
+
 Prerequisites
 ------
 

--- a/download_example/CMakeLists.txt
+++ b/download_example/CMakeLists.txt
@@ -1,0 +1,1 @@
+file(DOWNLOAD http://download.hrz.tu-darmstadt.de/media/FB20/GCC/project_files/mapmap/planesweep_320_256_96.bin ${CMAKE_BINARY_DIR}/demo/planesweep_320_256_96.bin)


### PR DESCRIPTION
Hello,

Damien from [tipi.build](https://tipi.build) here 😄 

I just added `tipi` support to your project that makes it quite easy to use with tipi.build then, for example a library user can simply add the following to `.tipi/deps` :

```json
{
  "dthuerck/mapmap_cpu" : {}
}
```

And can simply use the library without having to bother of installing any of the underlying dependencies.

I added another workflow with the `tipi ci` command which also runs the test. We could add a tipi.build pro subscription to the CI secrets so that you could also have manycore builds on a tipi node for the CI.

Feedback and improvements requests welcome !

Cheers,