### PR TITLE
Remove 'using' directive, it was making compilation fail

### DIFF
--- a/mapmap/source/graph.impl.h
+++ b/mapmap/source/graph.impl.h
@@ -29,8 +29,6 @@
 #include <mapmap/header/graph.h>
 #include <ext/dset/dset.h>
 
-using namespace oneapi;
-
 NS_MAPMAP_BEGIN
 
 /**


### PR DESCRIPTION
Greetings. Thank you for the nice mapmap package. I don't use it myself, but some of my dependencies do. 

I found an issue when compiling mapmap with an external TBB (I have a lot of dependencies, and including their code internally as your project does is not practical. I compiled with TBB 2021.5.0 from conda-forge.)

The compilation was failing because of an "ambiguous tbb" error, which I traced to your code having the line "using namespace oneapi". Normally such things are not good in header files, as they affect all the namespace resolution for anybody who ends up using your code one way or another. 

The mapmap code, its tests, and demo do build with this line removed. If it also works for you, maybe this change can be accepted as part of your code. Thanks.
