### PR TITLE
Fix a minor compilation issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 # set optimization options for GCC on unixoid systems
 # uses -march=native to make the compiler set __SSE4_2__, __AVX__ and
 # __AVX2__ to fit to the computer
-set(CMAKE_CXX_FLAGS "-Wall -march=native -Wfatal-errors")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -march=native -Wfatal-errors")
 if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops -mfpmath=sse -flto")
 else(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
When compiling mapmap_cpu as part of the bigger system, the compilation was failing, because instead of appending to CMAKE_CXX_FLAGS, this variable was being overwritten, so all the options for finding header files were being lost. This offers a fix. It should not change anything if this variable starts empty. 