### PR TITLE
:lipstick: fix the link to the original repo CI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 mapMAP MRF MAP Solver [![Build Status](https://github.com/dthuerck/mapmap_cpu/actions/workflows/master.yml/badge.svg)](https://github.com/dthuerck/mapmap_cpu/actions) 
-[![tipi.build](https://github.com/tipi-deps/mapmap_cpu/workflows/tipi.build/badge.svg) <img src="https://tipi.build/logo/tipi.build%20logo.svg" height="23" /> ](https://github.com/tipi-deps/mapmap_cpu/actions/workflows/ci.yml)
+[![tipi.build](https://github.com/dthuerck/mapmap_cpu/workflows/tipi.build/badge.svg) <img src="https://tipi.build/logo/tipi.build%20logo.svg" height="23" /> ](https://github.com/dthuerck/mapmap_cpu/actions/workflows/tipi.yml)
 ======
 
 Overview


### PR DESCRIPTION
Dear @dthuerck,

Just proposing a small fix so that the click on the tipi.build CI workflow in the Readme land on the right action page ( it was still moving to tipi-deps ).

Thanks for merging the support 👍 