### PR TITLE
fix queue initialization

### DIFF
--- a/mapmap/source/graph.impl.h
+++ b/mapmap/source/graph.impl.h
@@ -353,8 +353,8 @@ update_components()
 
         /* find random oder for start nodes */
         std::vector<luint_t> nodes(m_nodes.size());
-#if __cplusplus > 201100L
         std::iota(nodes.begin(), nodes.end(), 0);
+#if __cplusplus > 201100L
         std::random_device rd;
         std::mt19937 g(rd());
         std::shuffle(nodes.begin(), nodes.end(), g);

--- a/mapmap/source/multilevel_instances/group_same_label.impl.h
+++ b/mapmap/source/multilevel_instances/group_same_label.impl.h
@@ -62,8 +62,8 @@ group_nodes(
 
     /* create seed "queue" */
     std::vector<luint_t> qu(num_nodes);
-#if __cplusplus > 201100L
     std::iota(std::begin(qu), std::end(qu), 0);
+#if __cplusplus > 201100L
     std::random_device rd;
     std::mt19937 g(rd());
     std::shuffle(qu.begin(), qu.end(), g);


### PR DESCRIPTION
This PR fixes queue initialization when using older compilers or if this flag is not properly set. In our case was it `199711L` when it should be `201100L`.  When queue is not initialized it causes undefined behavior resulting in an application crash.

Also comparison should proprably be `__cplusplus >= 201100L` to include `c++11`, but this is minor issue.