### PR TITLE
remove incorrect throw() function specification

### DIFF
--- a/mapmap/header/costs.h
+++ b/mapmap/header/costs.h
@@ -132,7 +132,7 @@ public:
     ModeNotSupportedException(const std::string& err_msg);
     ~ModeNotSupportedException();
 
-    const char* what() const throw();
+    const char* what() const;
 
 protected:
     std::string m_err_msg;

--- a/mapmap/header/costs.h
+++ b/mapmap/header/costs.h
@@ -132,7 +132,7 @@ public:
     ModeNotSupportedException(const std::string& err_msg);
     ~ModeNotSupportedException();
 
-    const char* what() const;
+    const char* what() const noexcept;
 
 protected:
     std::string m_err_msg;

--- a/mapmap/header/dynamic_programming.h
+++ b/mapmap/header/dynamic_programming.h
@@ -78,7 +78,7 @@ public:
     ~CombinatorialDynamicProgramming();
 
     _s_t<COSTTYPE, SIMDWIDTH> optimize(
-        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution) throw();
+        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution);
 
 protected:
     void discover_leaves();

--- a/mapmap/header/graph.h
+++ b/mapmap/header/graph.h
@@ -40,7 +40,7 @@ public:
     ~Graph();
 
     void add_edge(const luint_t node_a, const luint_t node_b,
-        const scalar_t<COSTTYPE> weight) throw();
+        const scalar_t<COSTTYPE> weight);
     const std::vector<GraphNode>& nodes() const;
     const luint_t num_nodes() const;
     const std::vector<luint_t>& inc_edges(const luint_t node) const;

--- a/mapmap/header/mapmap.h
+++ b/mapmap/header/mapmap.h
@@ -66,15 +66,14 @@ public:
     ~mapMAP();
 
     /* set graph and label set */
-    void set_graph(Graph<COSTTYPE> * graph) throw();
-    void set_label_set(const LabelSet<COSTTYPE, SIMDWIDTH> * label_set)
-        throw();
+    void set_graph(Graph<COSTTYPE> * graph);
+    void set_label_set(const LabelSet<COSTTYPE, SIMDWIDTH> * label_set);
 
     /* alternatively - construct graph and label set */
     void add_edge(const luint_t node_a, const luint_t node_b,
-        const _s_t<COSTTYPE, SIMDWIDTH> weight = 1.0) throw();
+        const _s_t<COSTTYPE, SIMDWIDTH> weight = 1.0);
     void set_node_label_set(const luint_t node_id, const
-        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& label_set) throw();
+        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& label_set);
 
     /* set MRF cost functions (compatibility mode) */
     void set_unaries(const UnaryCosts<COSTTYPE, SIMDWIDTH> * unaries);
@@ -100,11 +99,11 @@ public:
 
     /* start optimization */
     _s_t<COSTTYPE, SIMDWIDTH> optimize(std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>&
-        solution) throw();
+        solution);
 
     /* start optimization with customized control flow */
     _s_t<COSTTYPE, SIMDWIDTH> optimize(std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>&
-        solution, const mapMAP_control& control_flow) throw();
+        solution, const mapMAP_control& control_flow);
 
 protected:
     /* setup, sanity checks and tools */

--- a/mapmap/header/optimizer_instances/dynamic_programming.h
+++ b/mapmap/header/optimizer_instances/dynamic_programming.h
@@ -67,7 +67,7 @@ public:
     ~CombinatorialDynamicProgramming();
 
     _s_t<COSTTYPE, SIMDWIDTH> optimize(
-        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution) throw();
+        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution);
 
 protected:
     void discover_leaves();

--- a/mapmap/header/tree_optimizer.h
+++ b/mapmap/header/tree_optimizer.h
@@ -43,7 +43,7 @@ public:
 
     /* optimization procedure - returns new objective value and solution */
     virtual _s_t<COSTTYPE, SIMDWIDTH> optimize(
-        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution) throw() = 0;
+        std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution) = 0;
 
 protected:
     bool data_complete();

--- a/mapmap/source/costs.impl.h
+++ b/mapmap/source/costs.impl.h
@@ -373,7 +373,7 @@ FORCEINLINE
 const char*
 ModeNotSupportedException::
 what()
-const throw()
+const
 {
     return m_err_msg.c_str();
 }

--- a/mapmap/source/costs.impl.h
+++ b/mapmap/source/costs.impl.h
@@ -373,7 +373,7 @@ FORCEINLINE
 const char*
 ModeNotSupportedException::
 what()
-const
+const noexcept
 {
     return m_err_msg.c_str();
 }

--- a/mapmap/source/dynamic_programming.impl.h
+++ b/mapmap/source/dynamic_programming.impl.h
@@ -335,7 +335,6 @@ _s_t<COSTTYPE, SIMDWIDTH>
 CombinatorialDynamicProgramming<COSTTYPE, SIMDWIDTH, UNARY, PAIRWISE>::
 optimize(
     std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution)
-throw()
 {
     if(!this->data_complete())
         throw std::domain_error("Data for optimization problem "

--- a/mapmap/source/graph.impl.h
+++ b/mapmap/source/graph.impl.h
@@ -185,7 +185,6 @@ add_edge(
     const luint_t node_a,
     const luint_t node_b,
     const COSTTYPE weight)
-throw()
 {
     if(std::max(node_a, node_b) >= m_num_nodes)
         throw std::runtime_error("Graph::add_edge: "

--- a/mapmap/source/mapmap.impl.h
+++ b/mapmap/source/mapmap.impl.h
@@ -92,7 +92,6 @@ void
 mapMAP<COSTTYPE, SIMDWIDTH>::
 set_graph(
     Graph<COSTTYPE> * graph)
-throw()
 {
     if(m_construct_graph)
         throw std::runtime_error("Setting the graph is not allowed "
@@ -111,7 +110,6 @@ void
 mapMAP<COSTTYPE, SIMDWIDTH>::
 set_label_set(
     const LabelSet<COSTTYPE, SIMDWIDTH> * label_set)
-throw()
 {
     if(m_construct_graph)
         throw std::runtime_error("Setting the label set is not allowed "
@@ -131,7 +129,6 @@ add_edge(
     const luint_t node_a,
     const luint_t node_b,
     const _s_t<COSTTYPE, SIMDWIDTH> weight)
-throw()
 {
     if(!m_construct_graph)
         throw std::runtime_error("Adding edges is only allowed "
@@ -149,7 +146,6 @@ mapMAP<COSTTYPE, SIMDWIDTH>::
 set_node_label_set(
     const luint_t node_id,
     const std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& label_set)
-throw()
 {
     if(!m_construct_graph)
         throw std::runtime_error("Setting a label set is only allowed "
@@ -278,7 +274,6 @@ _s_t<COSTTYPE, SIMDWIDTH>
 mapMAP<COSTTYPE, SIMDWIDTH>::
 optimize(
     std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution)
-throw()
 {
     /* initialize control flow with standard values */
     mapMAP_control std_control;
@@ -305,7 +300,6 @@ mapMAP<COSTTYPE, SIMDWIDTH>::
 optimize(
     std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution,
     const mapMAP_control& control_flow)
-throw()
 {
     _s_t<COSTTYPE, SIMDWIDTH> obj;
 

--- a/mapmap/source/optimizer_instances/dynamic_programming.impl.h
+++ b/mapmap/source/optimizer_instances/dynamic_programming.impl.h
@@ -161,7 +161,6 @@ _s_t<COSTTYPE, SIMDWIDTH>
 CombinatorialDynamicProgramming<COSTTYPE, SIMDWIDTH>::
 optimize(
     std::vector<_iv_st<COSTTYPE, SIMDWIDTH>>& solution)
-throw()
 {
     if(!this->data_complete())
         throw std::domain_error("Data for optimization problem "


### PR DESCRIPTION
`throw()` keword in incorrectly used. I can see it is meant to specify which function MAY throw but this specifier does the opposite. It specifies that this function will never throw and if it does it will cause application termination.

> A dynamic exception specification whose set of adjusted types is empty (after any packs are expanded) (since C++11) **is non-throwing**. A function with a non-throwing dynamic exception specification **does not allow any exceptions**.

> If the function throws an exception of the type not listed in its exception specification, the function [std::unexpected](https://en.cppreference.com/w/cpp/error/unexpected) is called. **The default function calls [std::terminate](https://en.cppreference.com/w/cpp/error/terminate)**, ....

https://en.cppreference.com/w/cpp/language/except_spec
https://en.cppreference.com/w/cpp/language/noexcept_spec